### PR TITLE
Remove reflection from about screen

### DIFF
--- a/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
@@ -49,7 +49,7 @@ public class AboutFragment extends Fragment {
         aq.id(R.id.listView1).itemClicked(new AboutItemClickListener());
 
         try {
-            aq.id(R.id.version).text("Version: " + Utils.getAppVersion(getActivity()) + getResources().getString(R.string.version_and_copyright));
+            aq.id(R.id.version).text(getResources().getString(R.string.version_and_copyright, Utils.getAppVersion(getActivity())));
         } catch (PackageManager.NameNotFoundException e) {
             Log.e(TAG, "Couldn't set text in about screen");
         }

--- a/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
@@ -55,6 +55,18 @@ public class AboutFragment extends Fragment {
         }
     }
 
+    private void openTellAFriendActivity() {
+        try {
+            Intent intent = new Intent(Intent.ACTION_SEND);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_SUBJECT, getResources().getString(R.string.share_subject));
+            intent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_text));
+            startActivity(Intent.createChooser(intent, getResources().getString(R.string.share)));
+        } catch (ActivityNotFoundException e) {
+            Log.e(TAG, "Couldn't open 'tell a friend about lokki' activity");
+        }
+    }
+
     private class AboutItemClickListener implements AdapterView.OnItemClickListener {
 
         @Override
@@ -63,26 +75,13 @@ public class AboutFragment extends Fragment {
             String url = aboutLinksUrls[position];
 
             switch (position) {
-
                 case 0: // Help
-                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
-                    break;
-
                 case 1: // Send feedback
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                     break;
 
                 case 2: // Tell a friend about Lokki
-                    try {
-                        Intent intent = new Intent(Intent.ACTION_SEND);
-                        intent.setType("text/plain");
-                        intent.putExtra(Intent.EXTRA_SUBJECT, getResources().getString(R.string.share_subject));
-                        intent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_text));
-                        startActivity(Intent.createChooser(intent, getResources().getString(R.string.share)));
-
-                    } catch (ActivityNotFoundException e) {
-                        Log.e(TAG, "Couldn't open 'tell a friend about lokki' activity");
-                    }
+                    openTellAFriendActivity();
                     break;
             }
         }

--- a/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/AboutFragment.java
@@ -6,6 +6,7 @@ package cc.softwarefactory.lokki.android;
 
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -22,7 +23,7 @@ import cc.softwarefactory.lokki.android.utils.Utils;
 
 public class AboutFragment extends Fragment {
 
-    private static final String TAG = "About";
+    private static final String TAG = "AboutFragment";
     private AQuery aq;
     private String[] aboutLinksUrls;
 
@@ -45,40 +46,45 @@ public class AboutFragment extends Fragment {
         aboutLinksUrls = getResources().getStringArray(R.array.about_links_url);
         String[] aboutLinks = getResources().getStringArray(R.array.about_links);
         aq.id(R.id.listView1).adapter(new ArrayAdapter<String>(getActivity(), android.R.layout.simple_list_item_1, aboutLinks));
-        aq.id(R.id.listView1).itemClicked(this, "onItemSelected");
+        aq.id(R.id.listView1).itemClicked(new AboutItemClickListener());
+
         try {
             aq.id(R.id.version).text("Version: " + Utils.getAppVersion(getActivity()) + getResources().getString(R.string.version_and_copyright));
-        } catch (Exception ex) {
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Couldn't set text in about screen");
         }
     }
 
-    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+    private class AboutItemClickListener implements AdapterView.OnItemClickListener {
 
-        Log.e(TAG, "onItemSelected: " + position + ", tag:" + parent.getTag());
-        String url = aboutLinksUrls[position];
+        @Override
+        public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+            Log.e(TAG, "onItemSelected: " + position + ", tag:" + parent.getTag());
+            String url = aboutLinksUrls[position];
 
-        switch (position) {
+            switch (position) {
 
-            case 0: // Help
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
-                break;
+                case 0: // Help
+                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                    break;
 
-            case 1: // Send feedback
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
-                break;
+                case 1: // Send feedback
+                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                    break;
 
-            case 2: // Tell a friend about Lokki
-                try {
-                    Intent intent = new Intent(Intent.ACTION_SEND);
-                    intent.setType("text/plain");
-                    intent.putExtra(Intent.EXTRA_SUBJECT, getResources().getString(R.string.share_subject));
-                    intent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_text));
-                    startActivity(Intent.createChooser(intent, getResources().getString(R.string.share)));
+                case 2: // Tell a friend about Lokki
+                    try {
+                        Intent intent = new Intent(Intent.ACTION_SEND);
+                        intent.setType("text/plain");
+                        intent.putExtra(Intent.EXTRA_SUBJECT, getResources().getString(R.string.share_subject));
+                        intent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.share_text));
+                        startActivity(Intent.createChooser(intent, getResources().getString(R.string.share)));
 
-                } catch (ActivityNotFoundException anfe) {
-                }
-                break;
-
+                    } catch (ActivityNotFoundException e) {
+                        Log.e(TAG, "Couldn't open 'tell a friend about lokki' activity");
+                    }
+                    break;
+            }
         }
     }
 }

--- a/App/src/main/res/values/strings.xml
+++ b/App/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <string name="my_visibility">My contacts can see me</string>
     <string name="privacy_policy_text">placeholder</string>
     <string name="license_link"><![CDATA[<a href=\"\">License terms</a>]]></string>
-    <string name="version_and_copyright">\nCopyright © F-Secure Corporation. \nAll rights reserved.</string>
+    <string name="version_and_copyright">Version: %1$s \nCopyright © F-Secure Corporation. \nAll rights reserved.</string>
     <string name="title_activity_first_time">FirstTimeActivity</string>
     <string name="i_agree">I have read and I agree</string>
     <string name="continue_with_terms">Continue</string>

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
@@ -1,0 +1,28 @@
+package cc.softwarefactory.lokki.android.espresso;
+
+import cc.softwarefactory.lokki.android.R;
+import cc.softwarefactory.lokki.android.espresso.utilities.TestUtils;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+public class AboutScreenTest extends MainActivityBaseTest {
+
+    private void enterAboutScreen() {
+        getActivity();
+        TestUtils.toggleNavigationDrawer();
+        onView(withText(R.string.about)).perform(click());
+    }
+
+    public void testAboutScreenOpens() {
+        enterAboutScreen();
+        onView(withText(R.string.help)).check(matches(isDisplayed()));
+        onView(withText(R.string.send_feedback)).check(matches(isDisplayed()));
+        onView(withText(R.string.about_link_tell_a_friend)).check(matches(isDisplayed()));
+    }
+}

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
@@ -20,8 +20,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 public class AboutScreenTest extends MainActivityBaseTest {
 
-    public static final String CHOOSER_ACTIVITY_PACKAGE_NAME = "com.android.internal.app.ChooserActivity";
-
     private void enterAboutScreen() {
         getActivity();
         TestUtils.toggleNavigationDrawer();
@@ -70,9 +68,11 @@ public class AboutScreenTest extends MainActivityBaseTest {
 
     public void testChooserIsOpenedWhenTellAFriendButtonIsClicked() {
         enterAboutScreen();
-        Instrumentation.ActivityMonitor monitor = getInstrumentation().addMonitor(CHOOSER_ACTIVITY_PACKAGE_NAME, null, false);
+        IntentFilter filter = new IntentFilter(Intent.ACTION_CHOOSER);
+        Instrumentation.ActivityMonitor monitor = getInstrumentation().addMonitor(filter, null, true);
+        assertEquals(0, monitor.getHits());
         onView(withText(R.string.about_link_tell_a_friend)).perform(click());
-        Activity activity = monitor.waitForActivityWithTimeout(TestUtils.WAIT_FOR_ACTIVITY_TIMEOUT);
-        assertNotNull(activity);
+        assertEquals(1, monitor.getHits());
+        getInstrumentation().removeMonitor(monitor);
     }
 }

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
@@ -1,17 +1,20 @@
 package cc.softwarefactory.lokki.android.espresso;
 
+import android.app.Activity;
+import android.app.Instrumentation;
+
 import cc.softwarefactory.lokki.android.R;
 import cc.softwarefactory.lokki.android.espresso.utilities.TestUtils;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 public class AboutScreenTest extends MainActivityBaseTest {
+
+    public static final String CHOOSER_ACTIVITY_PACKAGE_NAME = "com.android.internal.app.ChooserActivity";
 
     private void enterAboutScreen() {
         getActivity();
@@ -24,5 +27,13 @@ public class AboutScreenTest extends MainActivityBaseTest {
         onView(withText(R.string.help)).check(matches(isDisplayed()));
         onView(withText(R.string.send_feedback)).check(matches(isDisplayed()));
         onView(withText(R.string.about_link_tell_a_friend)).check(matches(isDisplayed()));
+    }
+
+    public void testChooserIsOpenedWhenTellAFriendButtonIsClicked() {
+        enterAboutScreen();
+        Instrumentation.ActivityMonitor monitor = getInstrumentation().addMonitor(CHOOSER_ACTIVITY_PACKAGE_NAME, null, false);
+        onView(withText(R.string.about_link_tell_a_friend)).perform(click());
+        Activity activity = monitor.waitForActivityWithTimeout(TestUtils.WAIT_FOR_ACTIVITY_TIMEOUT);
+        assertNotNull(activity);
     }
 }

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/AboutScreenTest.java
@@ -2,9 +2,15 @@ package cc.softwarefactory.lokki.android.espresso;
 
 import android.app.Activity;
 import android.app.Instrumentation;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.PatternMatcher;
 
 import cc.softwarefactory.lokki.android.R;
 import cc.softwarefactory.lokki.android.espresso.utilities.TestUtils;
+import cc.softwarefactory.lokki.android.utils.Utils;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -22,11 +28,44 @@ public class AboutScreenTest extends MainActivityBaseTest {
         onView(withText(R.string.about)).perform(click());
     }
 
-    public void testAboutScreenOpens() {
+    private IntentFilter getIntentFilterFromUri(String uriString) {
+        Uri uri = Uri.parse(uriString);
+        IntentFilter filter = new IntentFilter(Intent.ACTION_VIEW);
+        filter.addDataScheme(uri.getScheme());
+        filter.addDataAuthority(uri.getAuthority(), null);
+        filter.addDataPath(uri.getPath(), PatternMatcher.PATTERN_LITERAL);
+        return filter;
+    }
+
+    public void testAboutScreenOpens() throws PackageManager.NameNotFoundException {
         enterAboutScreen();
+        String versionAndCopyright = getResources().getString(R.string.version_and_copyright, Utils.getAppVersion(getActivity()));
+        onView(withText(versionAndCopyright)).check(matches(isDisplayed()));
         onView(withText(R.string.help)).check(matches(isDisplayed()));
         onView(withText(R.string.send_feedback)).check(matches(isDisplayed()));
         onView(withText(R.string.about_link_tell_a_friend)).check(matches(isDisplayed()));
+    }
+
+    public void testHelpPageIsLoadedWhenHelpButtonIsClicked() {
+        enterAboutScreen();
+        String urlString = getResources().getString(R.string.lokki_github_repo_link);
+        IntentFilter filter = getIntentFilterFromUri(urlString);
+        Instrumentation.ActivityMonitor monitor = getInstrumentation().addMonitor(filter, null, true);
+        assertEquals(0, monitor.getHits());
+        onView(withText(R.string.help)).perform(click());
+        assertEquals(1, monitor.getHits());
+        getInstrumentation().removeMonitor(monitor);
+    }
+
+    public void testFeedbackPageIsLoadedWhenFeedbackButtonIsClicked() {
+        enterAboutScreen();
+        String urlString = getResources().getString(R.string.lokki_github_repo_link);
+        IntentFilter filter = getIntentFilterFromUri(urlString);
+        Instrumentation.ActivityMonitor monitor = getInstrumentation().addMonitor(filter, null, true);
+        assertEquals(0, monitor.getHits());
+        onView(withText(R.string.send_feedback)).perform(click());
+        assertEquals(1, monitor.getHits());
+        getInstrumentation().removeMonitor(monitor);
     }
 
     public void testChooserIsOpenedWhenTellAFriendButtonIsClicked() {

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/ContactsScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/ContactsScreenTest.java
@@ -28,8 +28,7 @@ public class ContactsScreenTest extends MainActivityBaseTest {
 
     private void enterContactsScreen() {
         getActivity();
-        // TODO: hardcoded click position and menu text
-        onView(withId(R.id.decor_content_parent)).perform(TestUtils.clickScreenPosition(0, 0));
+        TestUtils.toggleNavigationDrawer();
         onView(withText("Contacts")).perform(click());
     }
 

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/ContactsScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/ContactsScreenTest.java
@@ -29,7 +29,7 @@ public class ContactsScreenTest extends MainActivityBaseTest {
     private void enterContactsScreen() {
         getActivity();
         TestUtils.toggleNavigationDrawer();
-        onView(withText("Contacts")).perform(click());
+        onView(withText(R.string.contacts)).perform(click());
     }
 
     public void testNoContactsShownWhenNoContacts() {

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/MainActivityBaseTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/MainActivityBaseTest.java
@@ -1,5 +1,6 @@
 package cc.softwarefactory.lokki.android.espresso;
 
+import android.content.res.Resources;
 import android.test.ActivityInstrumentationTestCase2;
 
 import cc.softwarefactory.lokki.android.MainActivity;
@@ -15,6 +16,10 @@ public abstract class MainActivityBaseTest extends ActivityInstrumentationTestCa
 
     public MainActivityBaseTest() {
         super(MainActivity.class);
+    }
+
+    protected Resources getResources() {
+        return getInstrumentation().getTargetContext().getResources();
     }
 
     @Override

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
@@ -23,6 +23,7 @@ public class TestUtils {
     final static String VALUE_TEST_USER_ID = "a1b2c3d4e5f6g7h8i9j10k11l12m13n14o15p16q";
     final static String VALUE_TEST_AUTH_TOKEN = "ABCDEFGHIJ";
 
+    public final static int WAIT_FOR_ACTIVITY_TIMEOUT = 10000; // milliseconds
 
     public static String getStringFromResources(Instrumentation instrumentation, int id) {
         return instrumentation.getTargetContext().getResources().getString(id);

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
@@ -62,6 +62,7 @@ public class TestUtils {
     }
 
     public static void toggleNavigationDrawer() {
+        // TODO: hardcoded click position and menu text
         onView(withId(R.id.decor_content_parent)).perform(clickScreenPosition(0, 0));
     }
 }

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/utilities/TestUtils.java
@@ -11,7 +11,11 @@ import android.support.test.espresso.action.Tap;
 import android.view.View;
 
 import cc.softwarefactory.lokki.android.MainActivity;
+import cc.softwarefactory.lokki.android.R;
 import cc.softwarefactory.lokki.android.utils.PreferenceUtils;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 public class TestUtils {
 
@@ -57,4 +61,7 @@ public class TestUtils {
                 Press.FINGER);
     }
 
+    public static void toggleNavigationDrawer() {
+        onView(withId(R.id.decor_content_parent)).perform(clickScreenPosition(0, 0));
+    }
 }


### PR DESCRIPTION
Function was called by giving its name as a String as an argument to a other function, so getting rid of it.

Also a very simple test for about screen – I didn't figure out yet how to check on tests if other activities, so it's lacking for now. Some other cleanup on tests too.

No need to merge yet if we want to have better tests for about screen first.

Connected to #82.