### PR TITLE
Use hint on email field & error if field is empty

### DIFF
--- a/App/src/main/java/cc/softwarefactory/lokki/android/SignupActivity.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/SignupActivity.java
@@ -72,7 +72,8 @@ public class SignupActivity extends ActionBarActivity {
         String accountName = email.toString();
         Log.e(TAG, "Email: " + accountName);
         if (accountName.isEmpty()) {
-            aq.id(R.id.email).text(R.string.type_your_email_address);
+            String errorMessage = getResources().getString(R.string.email_required);
+            aq.id(R.id.email).getEditText().setError(errorMessage);
             return;
         }
         PreferenceUtils.setValue(this, PreferenceUtils.KEY_USER_ACCOUNT, accountName);

--- a/App/src/main/res/layout/activity_signup.xml
+++ b/App/src/main/res/layout/activity_signup.xml
@@ -43,7 +43,7 @@
         android:layout_below="@id/explanation"
         android:layout_centerHorizontal="true"
         android:textColor="@android:color/black"
-        android:text="@string/type_your_email_address" />
+        android:hint="@string/type_your_email_address" />
 
     <Button
         android:id="@+id/signup_button"

--- a/App/src/main/res/values/strings.xml
+++ b/App/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
 
     <string name="about_link_tell_a_friend">Tell a friend about Lokki</string>
     <string name="lokki_github_repo_link">https://github.com/TheSoftwareFactory/lokki-android/</string>
-    <string name="no_contact_selected_toast">No contact selected</string>>
+    <string name="no_contact_selected_toast">No contact selected</string>
+    <string name="email_required">An email address is required.</string>
 
 </resources>

--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/SignUpScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/SignUpScreenTest.java
@@ -27,9 +27,11 @@ import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withHint;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
 
 public class SignUpScreenTest extends LokkiBaseTest {
 
@@ -39,13 +41,17 @@ public class SignUpScreenTest extends LokkiBaseTest {
         onView(withText(R.string.i_agree)).perform(click());
     }
 
-    private void signUpUsingEmail(String email) throws InterruptedException {
-        moveToSignUpScreen();
+    private void typeToEmailField(String email) throws InterruptedException {
         onView(withId(R.id.email)).perform(clearText(), typeText(email), closeSoftKeyboard());
 
         // Without this we get "PerformException: Error performing 'single click' on view".
         // See https://code.google.com/p/android-test-kit/issues/detail?id=44
         Thread.sleep(100);
+    }
+
+    private void signUpUsingEmail(String email) throws InterruptedException {
+        moveToSignUpScreen();
+        typeToEmailField(email);
 
         onView(withId(R.id.signup_button)).perform(click());
     }
@@ -103,8 +109,8 @@ public class SignUpScreenTest extends LokkiBaseTest {
         onView(withText(signupText)).check(matches(isDisplayed()));
     }
 
-    public void testTypeYourEmailAddressIsShownWhenFieldIsEmptyAndTryingToSignup() throws InterruptedException {
-        signUpUsingEmail("");
-        onView(allOf(withId(R.id.email), withText(R.string.type_your_email_address))).check(matches(isDisplayed()));
+    public void testEmailFieldHasHint() throws InterruptedException {
+        moveToSignUpScreen();
+        onView(withHint(R.string.type_your_email_address)).check(matches(isDisplayed()));
     }
 }


### PR DESCRIPTION
Connected to #97.

Also shows an error when trying to sign up with email field empty.

I *would* test that hint is shown only when the field is empty, but it doesn't seem to be supported. I also *would* test that the error message is actually shown, but EditText#setError() errors apparently cannot be matched with anything – at least uiautomatorviewer doesn't show it. 