### PR TITLE
Try to fix OOM issue in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ android:
     - sys-img-armeabi-v7a-android-21
 
 before_script:
+  # tell dx to use less memory, since we're running out of it
+  - sed -i 's/defaultMx="-Xmx1024M"/defaultMx="-Xmx512M"/' /usr/local/android-sdk/build-tools/21.1.2/dx
+
   - echo no | android create avd --force -n testAvd -t android-21 --abi armeabi-v7a
   - emulator -avd testAvd -no-audio -no-window &
   - android-wait-for-emulator


### PR DESCRIPTION
Apparently this error:

```
:App:preDexDevelopmentDebugTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':App:preDexDevelopmentDebugTest'.
> com.android.ide.common.internal.LoggedErrorException: Failed to run command:
/usr/local/android-sdk/build-tools/21.1.2/dx --dex --output /home/travis/build/TheSoftwareFactory/lokki-android/App/build/intermediates/pre-dexed/test/development/debug/bcprov-jdk15on-1.50-f201ad9550bd95f3c4d2b9b3c8e1f122363f61d4.jar /home/travis/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bcprov-jdk15on/1.50/be504b4901d75cbe129a178f5830e6c358ec214c/bcprov-jdk15on-1.50.jar
Error Code:
137
```

means that we're running out of memory. StackOverflow [gives this as a fix](https://stackoverflow.com/questions/22849720/android-gradle-build-script-returns-error-137-in-predexdebug), so trying it out.