### PR TITLE
Signup test timeout increase

### DIFF
--- a/App/src/test/java/cc/softwarefactory/lokki/android/espresso/SignUpScreenTest.java
+++ b/App/src/test/java/cc/softwarefactory/lokki/android/espresso/SignUpScreenTest.java
@@ -44,7 +44,7 @@ public class SignUpScreenTest extends LokkiBaseTest {
 
         // Without this we get "PerformException: Error performing 'single click' on view".
         // See https://code.google.com/p/android-test-kit/issues/detail?id=44
-        Thread.sleep(100);
+        Thread.sleep(1000);
     }
 
     private void signUpUsingEmail(String email) throws InterruptedException {


### PR DESCRIPTION
Increase the Thread.sleep() to 1000 to give time for the soft keyboard to close.