### PR TITLE
Fixed a typo in place creation help string

### DIFF
--- a/App/src/main/res/values-fi/strings.xml
+++ b/App/src/main/res/values-fi/strings.xml
@@ -28,7 +28,7 @@
     <string name="add_contact_dialog_save">Haluatko lisätä %1$s?</string>
     <string name="i_can_see">Näytä kartalla</string>
     <string name="can_see_me">Saa nähdä minut</string>
-    <string name="your_lokki_id">Sinun Lokki ID on:</string>
+    <string name="your_lokki_id">Sinun Lokki-tunnuksesi on:</string>
     <string name="version">Versio: %1$s</string>
     <string name="i_agree">Olen lukenut ja hyväksyn</string>
     <string name="continue_with_terms">Jatka</string>

--- a/App/src/main/res/values/strings.xml
+++ b/App/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="place_limit_reached">You cannot create more places. Maximum limit reached.</string>
     <string name="you_are_visible">You are now VISIBLE</string>
     <string name="you_are_invisible">You are now INVISIBLE</string>
-    <string name="places_how_to_create">To create a new place go to the map and long press the location where the place is located. Zoom the map to change the location's size, type a name and click OK.</string>
+    <string name="places_how_to_create">To create a new place go to the map and long press the location where the place is located. Zoom the map to change the location\'s size, type a name and click OK.</string>
     <string name="search_contacts">Search contacts…</string>
 
     <string name="map_mode_default">Default</string>

--- a/App/src/main/res/values/strings.xml
+++ b/App/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="place_limit_reached">You cannot create more places. Maximum limit reached.</string>
     <string name="you_are_visible">You are now VISIBLE</string>
     <string name="you_are_invisible">You are now INVISIBLE</string>
-    <string name="places_how_to_create">To create a new place go to the map and long press the location where the place is located. Zoom the map to change the locations size, type a name and click OK.</string>
+    <string name="places_how_to_create">To create a new place go to the map and long press the location where the place is located. Zoom the map to change the location's size, type a name and click OK.</string>
     <string name="search_contacts">Search contacts…</string>
 
     <string name="map_mode_default">Default</string>


### PR DESCRIPTION
The instructions for creating places had a missing apostrophe.