### PR TITLE
Ensured that wakelock is held before released.

### DIFF
--- a/App/src/main/java/cc/softwarefactory/lokki/android/services/LocationService.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/services/LocationService.java
@@ -284,7 +284,9 @@ public class LocationService extends Service implements LocationListener, Google
     @Override
     public void onDestroy() {
         Log.d(TAG, "onDestroy called");
-        wakeLock.release();
+        if(wakeLock.isHeld()) {
+            wakeLock.release();
+        }
         stopForeground(true);
         if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
             LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, this);


### PR DESCRIPTION
The recently added wakelock caused some errors on my phone (java.lang.RuntimeException: WakeLock under-locked C2DM_LIB), and this little change fixed it.