### PR TITLE
Client reacts better to server errors surrounding modifying place information

### DIFF
--- a/App/src/main/java/cc/softwarefactory/lokki/android/errors/PlaceError.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/errors/PlaceError.java
@@ -2,14 +2,15 @@ package cc.softwarefactory.lokki.android.errors;
 
 import cc.softwarefactory.lokki.android.R;
 
-public enum AddPlaceError {
+public enum PlaceError {
     PLACE_LIMIT("place_limit_reached", R.string.place_limit_reached),
-    NAME_IN_USE("place_name_already_in_use", R.string.place_name_already_in_use);
+    NAME_IN_USE("place_name_already_in_use", R.string.place_name_already_in_use),
+    TOO_LONG_NAME("place_name_too_long", R.string.place_name_too_long);
 
     private String name;
     private int errorMessage;
 
-    AddPlaceError(String name, int errorMessage) {
+    PlaceError(String name, int errorMessage) {
         this.name = name;
         this.errorMessage = errorMessage;
     }
@@ -22,8 +23,8 @@ public enum AddPlaceError {
         return errorMessage;
     }
 
-    public static AddPlaceError getEnum(String serverMessage) {
-        for (AddPlaceError ape : AddPlaceError.values()) {
+    public static PlaceError getEnum(String serverMessage) {
+        for (PlaceError ape : PlaceError.values()) {
             if (ape.getName().equals(serverMessage)) {
                 return ape;
             }

--- a/App/src/main/java/cc/softwarefactory/lokki/android/fragments/PlacesFragment.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/fragments/PlacesFragment.java
@@ -375,16 +375,6 @@ public class PlacesFragment extends Fragment {
                 .show();
     }
 
-    static public boolean placeNameAlreadyInUse(String name) throws JSONException {
-        Iterator<String> it = MainApplication.places.keys();
-        while(it.hasNext()) {
-            JSONObject object = (JSONObject)MainApplication.places.get(it.next());
-            if(object.getString("name").toLowerCase().trim().equals(name.toLowerCase().trim()))
-                return true;
-        }
-        return false;
-    }
-
     static public void renamePlaceLocally(final String key, JSONObject placeObj) {
         try {
             MainApplication.places.remove(key);
@@ -398,11 +388,6 @@ public class PlacesFragment extends Fragment {
 
         Log.d(TAG, "renamePlace");
         try {
-            if(placeNameAlreadyInUse(newName)) {
-                Toast.makeText(context, R.string.place_name_already_in_use, Toast.LENGTH_LONG).show();
-                return;
-            }
-
             Iterator<String> keys = MainApplication.places.keys();
             while (keys.hasNext()) {
                 String key = keys.next();

--- a/App/src/main/java/cc/softwarefactory/lokki/android/services/LocationService.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/services/LocationService.java
@@ -284,7 +284,9 @@ public class LocationService extends Service implements LocationListener, Google
     @Override
     public void onDestroy() {
         Log.d(TAG, "onDestroy called");
-        wakeLock.release();
+        if(wakeLock.isHeld()) {
+            wakeLock.release();
+        }
         stopForeground(true);
         if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
             LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, this);

--- a/App/src/main/res/values-fi/strings.xml
+++ b/App/src/main/res/values-fi/strings.xml
@@ -74,6 +74,7 @@
     <string name="email_required">Sähköpostiosoite on pakollinen.</string>
     <string name="required">Pakollinen</string>
     <string name="place_name_already_in_use">Nimi on jo käytössä</string>
+    <string name="place_name_too_long">Paikan nimi on liian pitkä.</string>
     <string name="add_place">Lisää paikka</string>
     <string name="gps_disabled">Lokki haluaa käyttää sijaintiasi. Ota sijaintipalvelut käyttöön.</string>
     <string name="ignore">Ohita</string>

--- a/App/src/main/res/values/strings.xml
+++ b/App/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="email_required">An email address is required.</string>
     <string name="required">Required</string>
     <string name="place_name_already_in_use">Name is already in use</string>
+    <string name="place_name_too_long">Place has too long name.</string>
     <string name="add_place">Add place</string>
     <string name="add_place_hint">Hint:You can zoom and pan the map to adjust the location.</string>
     <string name="gps_disabled">Lokki needs access to your location. Please turn on location access.</string>


### PR DESCRIPTION
The client now informs the user if renaming place failed on the server. I also removed the local name collision checking since it's now obsolete (server checks it among other things).