### PR TITLE
Disable logging for production release environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ App/build
 build
 analytics_global_tracker_config.xml
 *.keystore
+App/personal-android-key.txt

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -28,7 +28,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             if (file("lokki-release.keystore").exists()) {
                 signingConfig signingConfigs.release
             }

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -5,6 +5,7 @@ android {
     buildToolsVersion '22.0.1'
     lintOptions {
         abortOnError true
+        disable "MissingTranslation"
     }
 
     defaultConfig {

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -36,8 +36,12 @@ android {
     }
 
     productFlavors {
-        development {}
-        production {}
+        development {
+            resValue "string", "personal_android_key", file("personal-android-key.txt").getText()
+        }
+        production {
+            resValue "string", "personal_android_key", "AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E"
+        }
     }
 
     sourceSets {

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -26,6 +26,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            resValue "string", "personal_android_key", "AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E"
+            if (file("personal-android-key.txt").exists()) {
+                resValue "string", "personal_android_key", file("personal-android-key.txt").getText()
+            }
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
@@ -36,12 +42,8 @@ android {
     }
 
     productFlavors {
-        development {
-            resValue "string", "personal_android_key", file("personal-android-key.txt").getText()
-        }
-        production {
-            resValue "string", "personal_android_key", "AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E"
-        }
+        development {}
+        production {}
     }
 
     sourceSets {

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -25,14 +25,17 @@ android {
         }
     }
 
+    def defaultKey = "AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E"
+
     buildTypes {
         debug {
-            resValue "string", "personal_android_key", "AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E"
+            resValue "string", "personal_android_key", defaultKey
             if (file("personal-android-key.txt").exists()) {
                 resValue "string", "personal_android_key", file("personal-android-key.txt").getText()
             }
         }
         release {
+            resValue "string", "personal_android_key", defaultKey
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             if (file("lokki-release.keystore").exists()) {

--- a/App/personal-android-key.example.txt
+++ b/App/personal-android-key.example.txt
@@ -1,0 +1,1 @@
+AAzaSyA2eooz2DQbmBYckvAaWRxA3yeFTiUs32g #This is an example key. Create a new file 'personal-android-key.txt' to the App folder. Replace this whole line (including this comment) with your own key.

--- a/App/proguard-rules.txt
+++ b/App/proguard-rules.txt
@@ -34,9 +34,24 @@
 -dontusemixedcaseclassnames
 -dontskipnonpubliclibraryclasses
 -verbose
+-dontobfuscate
+-forceprocessing
+
+-keep class * extends android.app.Activity
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+    public static *** wtf(...);
+}
+
+#Building with optimization enabled fails without this.
+-optimizations !code/allocation/variable
 
 # We restrict a few more optimizations for the maps library.
--optimizations !code/simplification/arithmetic,!field/*,!class/merging/*,!code/simplification/variable
+#-optimizations !code/simplification/arithmetic,!field/*,!class/merging/*,!code/simplification/variable
 
 -keep public class * extends android.app.Activity
 -keep public class * extends android.app.Application
@@ -109,3 +124,4 @@
 
 # Unused RoundedImageView dependancies
 -dontwarn com.squareup.picasso.Transformation
+

--- a/App/proguard-rules.txt
+++ b/App/proguard-rules.txt
@@ -47,11 +47,8 @@
     public static *** wtf(...);
 }
 
-#Building with optimization enabled fails without this.
--optimizations !code/allocation/variable
-
-# We restrict a few more optimizations for the maps library.
-#-optimizations !code/simplification/arithmetic,!field/*,!class/merging/*,!code/simplification/variable
+# We restrict a few more optimizations for the maps library. Building fails without !code/allocation/variable.
+-optimizations !code/simplification/arithmetic,!field/*,!class/merging/*,!code/simplification/variable, !code/allocation/variable
 
 -keep public class * extends android.app.Activity
 -keep public class * extends android.app.Application

--- a/App/src/main/AndroidManifest.xml
+++ b/App/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
 
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyCmHGAOJLyg_cMw-SuDD-Jfh4yiZZ-XI3E" />
+            android:value="@string/personal_android_key" />
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/App/src/main/java/cc/softwarefactory/lokki/android/fragments/MapViewFragment.java
+++ b/App/src/main/java/cc/softwarefactory/lokki/android/fragments/MapViewFragment.java
@@ -116,7 +116,7 @@ public class MapViewFragment extends Fragment {
 
     @Override
     public void onDestroyView() {
-        // Trying to clean up properties (not to hold anything coming from the map (and avoid mem leaks).
+        // Trying to clean up properties (not to hold anything coming from the map (and avoid mem leaks)).
         fragment = null;
         map = null;
         aq = null;


### PR DESCRIPTION
The release branch can be deprecated after these changes, because there is no need to manually comment out all the logging for production release version.